### PR TITLE
CASH-1155 - Add support for void (cancel order) requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 composer.phar
 phpunit.xml
+.idea

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "psr-4": { "Omnipay\\MultiSafepay\\" : "src/" }
     },
     "require": {
-        "omnipay/common": "^3"
+        "omnipay/common": "^3",
+        "ext-json": "*"
     },
     "require-dev": {
         "omnipay/tests": "^3",

--- a/src/Message/RestCancelOrderRequest.php
+++ b/src/Message/RestCancelOrderRequest.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+namespace Omnipay\MultiSafepay\Message;
+
+/**
+ * Cancel an order
+ *
+ * @link https://docs.multisafepay.com/api/#update-an-order
+ */
+final class RestCancelOrderRequest extends RestAbstractRequest
+{
+    public function getData()
+    {
+        parent::getData();
+
+        $this->validate('transactionId');
+
+        $transactionId = $this->getTransactionId();
+
+        return compact('transactionId');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function sendData($data)
+    {
+        $httpResponse = $this->sendRequest(
+            'PATCH',
+            '/orders/' . $data['transactionId'],
+            '{"status":"cancelled"}'
+        );
+
+        $this->response = new RestCancelOrderResponse(
+            $this,
+            json_decode($httpResponse->getBody()->getContents(), true)
+        );
+
+        return $this->response;
+    }
+}

--- a/src/Message/RestCancelOrderResponse.php
+++ b/src/Message/RestCancelOrderResponse.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+
+namespace Omnipay\MultiSafepay\Message;
+
+final class RestCancelOrderResponse extends RestAbstractResponse
+{
+}

--- a/src/RestGateway.php
+++ b/src/RestGateway.php
@@ -6,6 +6,7 @@
 namespace Omnipay\MultiSafepay;
 
 use Omnipay\Common\AbstractGateway;
+use Omnipay\MultiSafepay\Message\RestCancelOrderRequest;
 
 /**
  * MultiSafepay REST Api gateway.
@@ -254,5 +255,10 @@ class RestGateway extends AbstractGateway
             'Omnipay\MultiSafepay\Message\RestCompletePurchaseRequest',
             $parameters
         );
+    }
+
+    public function void(array $parameters = [])
+    {
+        return $this->createRequest(RestCancelOrderRequest::class, $parameters);
     }
 }

--- a/tests/Message/RestCancelOrderRequestTest.php
+++ b/tests/Message/RestCancelOrderRequestTest.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Message;
+
+use Omnipay\MultiSafepay\Message\RestCancelOrderRequest;
+use Omnipay\MultiSafepay\Message\RestCancelOrderResponse;
+use Omnipay\Tests\TestCase;
+
+final class RestCancelOrderRequestTest extends TestCase
+{
+    /**
+     * @var RestCancelOrderRequest
+     */
+    private $request;
+
+    protected function setUp()
+    {
+        $this->request = new RestCancelOrderRequest(
+            $this->getHttpClient(),
+            $this->getHttpRequest()
+        );
+
+        $this->request->initialize(
+            [
+                'api_key' => '123456789',
+                'transactionId' => 'qux',
+            ]
+        );
+    }
+
+    public function testSendFailure()
+    {
+        $this->setMockHttpResponse('RestCancelOrderFailure.txt');
+
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isRedirect());
+        $this->assertInstanceOf(RestCancelOrderResponse::class, $response);
+
+        $this->assertFalse($response->isSuccessful());
+    }
+
+    public function testSendSuccess()
+    {
+        $this->setMockHttpResponse('RestCancelOrderSuccess.txt');
+
+        $response = $this->request->send();
+
+        $this->assertFalse($response->isRedirect());
+        $this->assertInstanceOf(RestCancelOrderResponse::class, $response);
+
+        $this->assertTrue($response->isSuccessful());
+    }
+}

--- a/tests/Mock/RestCancelOrderFailure.txt
+++ b/tests/Mock/RestCancelOrderFailure.txt
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Date: Fri, 05 Feb 2016 09:18:54 GMT
+Server: Apache
+Vary: Accept-Encoding
+Content-Length: 26
+Content-Type: application/json; charset=UTF-8;
+
+{"success":false,"data":{}}

--- a/tests/Mock/RestCancelOrderSuccess.txt
+++ b/tests/Mock/RestCancelOrderSuccess.txt
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Date: Fri, 05 Feb 2016 09:18:54 GMT
+Server: Apache
+Vary: Accept-Encoding
+Content-Length: 26
+Content-Type: application/json; charset=UTF-8;
+
+{"success":true,"data":{}}

--- a/tests/RestGatewayTest.php
+++ b/tests/RestGatewayTest.php
@@ -1,5 +1,6 @@
 <?php namespace Omnipay\MultiSafepay;
 
+use Omnipay\MultiSafepay\Message\RestCancelOrderRequest;
 use Omnipay\Tests\GatewayTestCase;
 
 class RestGatewayTest extends GatewayTestCase
@@ -55,5 +56,13 @@ class RestGatewayTest extends GatewayTestCase
 
         $this->assertInstanceOf('Omnipay\MultiSafepay\Message\RestCompletePurchaseRequest', $request);
         $this->assertEquals($request->getAmount(), 10.00);
+    }
+
+    public function testVoid()
+    {
+        $request = $this->gateway->void(['transactionId' => 'barfoo']);
+
+        self::assertInstanceOf(RestCancelOrderRequest::class, $request);
+        self::assertEquals('barfoo', $request->getTransactionId());
     }
 }


### PR DESCRIPTION
https://myonlinestore.atlassian.net/browse/CASH-1155

Unfortunately, only the REST api has support for cancel (update) order requests, the deprecated XML version does not.